### PR TITLE
feat(api/splits): add stock split api with caching

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -39,7 +39,8 @@
     {
       "files": [
         "src/pages/**/*.page.tsx",
-        "src/pages/**/*.page.ts"
+        "src/pages/**/*.page.ts",
+        "src/pages/**/*.api.ts"
       ],
       "rules": {
         "import/no-default-export": "off",

--- a/next.config.js
+++ b/next.config.js
@@ -8,5 +8,5 @@ const withMDX = require('@next/mdx')({
 
 module.exports = withMDX({
   reactStrictMode: true,
-  pageExtensions: ['page.tsx', 'page.ts', 'page.mdx'],
+  pageExtensions: ['page.tsx', 'page.ts', 'page.mdx', 'api.ts'],
 })

--- a/src/pages/api/v0/prices/[symbol]/splits.api.ts
+++ b/src/pages/api/v0/prices/[symbol]/splits.api.ts
@@ -1,0 +1,81 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import fetch from 'node-fetch'
+
+const CRYPTO = ['BTC', 'ETH', 'DFI', 'USDC', 'USDT', 'DOGE', 'LTC', 'BCH']
+const CURRENCY = ['SGD', 'EUR']
+const IEX_CLOUD_API_TOKEN = process.env.IEX_CLOUD_API_TOKEN
+
+export interface StockSplit {
+  symbol: string
+  description: string
+  /**
+   * In seconds.
+   */
+  expectedTime: number
+  factor: {
+    from: number
+    to: number
+  }
+}
+
+export default async function handle (req: NextApiRequest, res: NextApiResponse<StockSplit[]>): Promise<void> {
+  const symbol = req.query.symbol
+  if (Array.isArray(symbol)) {
+    res.status(400)
+    return
+  }
+
+  const splits = await getStockSplit(symbol as string)
+
+  res.status(200)
+    .setHeader('Cache-Control', 'max-age=86400, public')
+    .json(splits)
+}
+
+async function getStockSplit (symbol: string): Promise<StockSplit[]> {
+  if (isIgnoredSymbol(symbol)) {
+    return []
+  }
+
+  const response = await fetch(`https://cloud.iexapis.com/stable/stock/${symbol}/splits/next?token=${IEX_CLOUD_API_TOKEN}`)
+  if (response.status === 404) {
+    return []
+  }
+
+  if (response.status !== 200) {
+    throw new Error(`error: ${response.status}`)
+  }
+
+  try {
+    const body: any = await response.json()
+    if (body.length === 0) {
+      return []
+    }
+
+    return body.map((item: any): StockSplit => {
+      return {
+        symbol: symbol,
+        description: item.description,
+        expectedTime: Math.floor(new Date(item.exDate).getTime() / 1000),
+        factor: {
+          from: item.fromFactor,
+          to: item.toFactor
+        }
+      }
+    })
+  } catch (e) {
+    throw new Error(`error: unknown`)
+  }
+}
+
+function isIgnoredSymbol (symbol: string): boolean {
+  if (CRYPTO.includes(symbol)) {
+    return true
+  }
+
+  if (CURRENCY.includes(symbol)) {
+    return true
+  }
+
+  return false
+}

--- a/src/pages/prices.page.tsx
+++ b/src/pages/prices.page.tsx
@@ -14,7 +14,7 @@ export default function PricesPage ({ prices }: PricesPageProps): JSX.Element {
   return (
     <Container className='pt-8 pb-24'>
       <div>
-        <h1 className='font-semibold text-lg my-6'>
+        <h1 className='font-semibold text-lg mb-6'>
           Total Prices: {prices.length}
         </h1>
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Add stock split API for `https://oracles.dfc.fuxing.dev/api/v0/prices/:SYMBOL/splits` with caching.